### PR TITLE
Update UIDevice+Hardware.m

### DIFF
--- a/SDK/Categories/UIDevice+Hardware/UIDevice+Hardware.m
+++ b/SDK/Categories/UIDevice+Hardware/UIDevice+Hardware.m
@@ -21,8 +21,6 @@
         self.batteryMonitoringEnabled = YES;
     }
     
-    [self setBatteryMonitoringEnabled:YES];
-    
     float batteryLevel = self.batteryLevel;
     
     if (!batteryMonitoring)


### PR DESCRIPTION
Calling  [self setBatteryMonitoringEnabled:YES] sometimes crashed the app. No obvious way to reproduce, but either way part of the code was not necessary.

Crash log:
Crashed: com.apple.main-thread
0  IOKit                          0x180e819f0 IOServiceAddMatchingNotification + 40
1  UIKit                          0x185fcd0e0 -[UIDevice setBatteryMonitoringEnabled:] + 192
2  UIKit                          0x185fcd0e0 -[UIDevice setBatteryMonitoringEnabled:] + 192
3  Wandera                        0x10024e070 -[UIDevice(Hardware) hay_batteryLevel] (UIDevice+Hardware.m:24)